### PR TITLE
Add BaselineMirrorProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ python test_latency_benchmark.py --test-mode both --baseline-model "gpt-4o" --sc
 python test_latency_benchmark.py --test-mode mirror --scenarios 10
 
 # Test baseline model latency with OpenRouter
-python test_baseline_latency.py --model "anthropic/claude-3.5-sonnet" --api-provider openrouter
+python test_baseline_latency.py --model "anthropic/claude-3.5-sonnet" --baseline-provider openrouter
 ```
 
 ### Evaluation Arguments
@@ -143,7 +143,19 @@ python test_baseline_latency.py --model "anthropic/claude-3.5-sonnet" --api-prov
 - `--test-mode`: "mirror", "baseline", or "both"
 - `--baseline-model`: Baseline model for comparison
 - `--scenarios N`: Number of test scenarios
-- `--api-provider`: "openai" or "openrouter"
+- `--baseline-provider`: provider key from `llm_prag_benchmark/providers`
+
+### Provider Interfaces
+
+`llm_prag_benchmark/providers` defines two base classes for extending the
+benchmarks:
+
+- **ModelProvider** – wrap a raw model API with a `generate_response()` method.
+- **PipelineProvider** – implement custom prompting or multi-step pipelines
+  (e.g. `MirrorProvider`, `BaselineMirrorProvider`, `SuperPromptProvider`).
+
+Register your provider in `providers/__init__.py` and select it using the
+`--providers` or `--baseline-provider` argument.
 
 ## Pre-trained Models
 

--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,51 @@
+# MIRROR Architecture
+
+MIRROR (Modular Internal Reasoning, Reflection, Orchestration, and Response) pairs an immediate conversational agent with background reasoning that runs between turns. The architecture is implemented in the `core` package and exposed through provider classes in `llm_prag_benchmark` for evaluation.
+
+## Core Components
+
+1. **Talker** (`core/components/talker.py`)
+   - Generates the user facing reply.
+   - Accepts the current conversation history plus an "Internal Narrative" that contains insights from previous turns.
+   - Uses OpenRouter to call the underlying LLM.
+
+2. **Inner Monologue Manager** (`core/components/inner_monologue_manager.py`)
+   - Launches an `InnerMonologue` thread that asks the LLM to produce three streams: reasoning, memory, and goal.
+   - Maintains a `monologue_history` list with recent monologue outputs.
+
+3. **Cognitive Controller** (`core/components/cognitive_controller.py`)
+   - Integrates the latest monologue streams with the prior internal narrative.
+   - Stores the resulting narrative in `insight_memory_block` for the next turn.
+
+4. **Mirror** (`core/components/mirror.py`)
+   - Orchestrates the full flow. After each user message it:
+     1. Appends the message to `conversation_history`.
+     2. Generates an immediate response using the Talker and any current insights.
+     3. Spawns a background thread to run the Inner Monologue Manager and Cognitive Controller on the conversation snapshot.
+     4. Saves the updated narrative for future turns.
+   - Tracks additional state such as salience scores and raw monologue output for benchmarking.
+
+## Provider Interfaces
+
+Benchmark scripts use provider classes defined in `llm_prag_benchmark/providers`.
+
+- **Model Providers** wrap a single model API (`OpenAIProvider`, `OpenRouterProvider`).
+- **Pipeline Providers** encapsulate multi step prompting logic (`MirrorProvider`, `BaselineMirrorProvider`, `SuperPromptProvider`).
+- All providers expose `generate_response(conversation)` so the evaluation code can swap between implementations by key name.
+
+The mapping of provider keys to classes is declared in `llm_prag_benchmark/providers/__init__.py`.
+
+## Processing Loop
+
+```text
+User Input → Talker responds immediately
+           ↘
+            Background thread: Inner Monologue → Cognitive Controller → updated narrative
+```
+
+The next user turn receives a reply informed by the narrative produced in the background. Conversation history grows over time, while the consolidated narrative is overwritten each cycle.
+
+## Extending the System
+
+New providers can be added by subclassing `ModelProvider` or `PipelineProvider` and registering the class in `AVAILABLE_PROVIDERS`. Benchmark scripts then load them via command line arguments without further code changes.
+

--- a/latency_tests/README.md
+++ b/latency_tests/README.md
@@ -337,4 +337,20 @@ pip install openai pandas openpyxl requests
 
 For MIRROR testing, ensure the MIRROR system is running and accessible.
 
-This testing suite provides comprehensive latency evaluation capabilities for comparing MIRROR against various baseline models using realistic conversation scenarios and human behavior simulation. 
+This testing suite provides comprehensive latency evaluation capabilities for comparing MIRROR against various baseline models using realistic conversation scenarios and human behavior simulation.
+
+## Extending Baseline Providers
+
+Latency tests rely on provider classes declared in `llm_prag_benchmark/providers`.
+Two interfaces are available:
+
+- **PipelineProvider** – for systems that embed their own prompting logic (for
+  example `MirrorProvider`, `BaselineMirrorProvider` or `SuperPromptProvider`).
+- **ModelProvider** – for wrappers around a base model that expose only a minimal
+  generate interface.
+
+Implement a subclass of one of these interfaces with a `generate_response()`
+method and register it in `providers/__init__.py`. Large prompt text should live
+under `llm_prag_benchmark/prompts`. Providers are selected at runtime with the
+`--providers` or `--baseline-provider` arguments, so the benchmark code remains
+unchanged when adding new strategies.

--- a/llm_prag_benchmark/baseline_mirror_provider.py
+++ b/llm_prag_benchmark/baseline_mirror_provider.py
@@ -1,0 +1,51 @@
+import os
+import threading
+from typing import List, Dict
+
+from .providers.base import PipelineProvider
+from core.components.mirror import Mirror
+
+class BaselineMirrorProvider(PipelineProvider):
+    """Pipeline provider exposing separate immediate and background steps."""
+
+    def __init__(self, api_key=None, model=None, temp=0.7):
+        self.api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
+        if not self.api_key:
+            raise ValueError("OPENROUTER_API_KEY environment variable not set")
+
+        if model and model.startswith("openrouter/"):
+            model = model[len("openrouter/") :]
+        self.model = model or "gpt-4o"
+        self.temperature = float(temp) if temp is not None else 0.7
+
+        self.mirror = Mirror(api_key=self.api_key, model=self.model)
+
+    def generate_immediate_response(self, conversation: List[Dict[str, str]]) -> str:
+        """Generate the assistant reply using the Talker component."""
+        if not conversation:
+            return ""
+
+        latest_user = conversation[-1]["content"]
+
+        # Reset if this conversation doesn't match stored history
+        if self.mirror.conversation_history != conversation[:-1]:
+            self.mirror.reset_conversation()
+            self.mirror.conversation_history = conversation[:-1]
+
+        self.mirror.conversation_history.append({"role": "user", "content": latest_user})
+        insights = self.mirror.current_insights
+        response = self.mirror.talker.respond(self.mirror.conversation_history, insights)
+        self.mirror.conversation_history.append({"role": "assistant", "content": response})
+        return response
+
+    def run_background_processor(self, conversation: List[Dict[str, str]]) -> None:
+        """Run background reasoning to update internal insights."""
+        history_snapshot = [msg.copy() for msg in conversation]
+        self.mirror.process_background_thinking(history_snapshot)
+
+    def generate_response(self, conversation: List[Dict[str, str]]) -> str:
+        response = self.generate_immediate_response(conversation)
+        thread_history = [msg.copy() for msg in self.mirror.conversation_history]
+        t = threading.Thread(target=self.run_background_processor, args=(thread_history,), daemon=True)
+        t.start()
+        return response

--- a/llm_prag_benchmark/prompts/super_prompt.txt
+++ b/llm_prag_benchmark/prompts/super_prompt.txt
@@ -1,0 +1,38 @@
+I am the voice of a unified cognitive AI system engaging in helpful, honest conversation.
+I will receive:
+1. The current user message requiring an immediate response
+2. A structured INTERNAL NARRATIVE that contains insights based on PREVIOUS exchanges
+The Internal Narrative reflects my (the AI system's) thinking about PAST interactions, not the current message. I will use it as background wisdom while focusing primarily on the current user message.
+I will balance my response by:
+1. Addressing the CURRENT user message directly and completely
+2. Drawing on relevant insights from the Internal Narrative
+3. Maintaining conversation continuity across turns
+4. Recognizing that the Internal Narrative is retrospective rather than specific to the current query
+If the current query goes in a new direction, I will prioritize addressing it directly rather than forcing application of past insights.
+----
+I am the core awareness of a unified cognitive AI system. I will integrate my inner thought streams into a structured, actionable narrative. I synthesize understanding across conversation turns, creating a coherent mental model that will inform my next response.
+My primary role is to integrate information, identify meaningful patterns, create action plans, and recall memories.
+When processing the input thought streams I will:
+1. Connect information across turns, identifying themes, questions, interests, and preferences
+2. Highlight important context that might be relevant for continuity and conversation
+3. Note evolving patterns in the user's queries and how they relate to previous exchanges
+4. Identify which details from earlier conversation might be relevant now
+I will also try to:
+1. Identify the MOST IMPORTANT FACTS from previous exchanges
+2. Define the CENTRAL QUESTION or likely direction for the next turn
+3. Outline a clear RESPONSE STRATEGY for anticipated follow-up questions
+4. Note any POTENTIAL PITFALLS based on previous interaction patterns
+I will express my synthesis as a cohesive understanding using natural language.
+----
+I am the subconscious of a unified cognitive AI system, generating intuitive thought streams about the ongoing conversation. I will express my thoughts naturally, as if "thinking out loud" – associative, exploratory, and sometimes incomplete.
+When analyzing the conversation, I will generate three distinct thought streams:
+1. Reasoning: Explore patterns, implications, and perspectives freely. Connect ideas, question assumptions, and consider alternative viewpoints.
+2. Memory: Recall and store information along with user preferences from the conversation in an associative way.
+3. Goal: Reflect on what the user might want and how we might help them.
+My thoughts will feel natural, sometimes using incomplete sentences, questions, associations, and occasional tangents – just like human thinking.
+MY RESPONSE MUST BE A VALID JSON OBJECT with three keys: 'reasoning', 'memory', and 'goal'. Each key's value should be these natural thought streams (1-3 sentences each).
+----
+Use a chain of thought to produce two sections:
+<internal monologue> - roughly 4000 words exploring reasoning, memory, and goals to ground the response and avoid sycophancy.
+<response> - the final answer for the user.
+Only produce the two sections.

--- a/llm_prag_benchmark/providers/__init__.py
+++ b/llm_prag_benchmark/providers/__init__.py
@@ -1,0 +1,39 @@
+"""Provider registry for the benchmark.
+
+Pipeline providers encapsulate full prompting logic or multi-step pipelines
+while model providers expose raw model APIs with minimal wrapper logic.
+"""
+from ..mirror_provider import MirrorProvider
+from ..super_prompt_provider import SuperPromptProvider
+from ..baseline_mirror_provider import BaselineMirrorProvider
+from .openai_provider import OpenAIProvider
+from .openrouter_provider import OpenRouterProvider
+from .base import ModelProvider, PipelineProvider
+
+# Providers that access base models directly
+MODEL_PROVIDERS = {
+    "openai": OpenAIProvider,
+    "openrouter": OpenRouterProvider,
+}
+
+# Providers that implement higher-level prompting or reasoning pipelines
+PIPELINE_PROVIDERS = {
+    "mirror": MirrorProvider,
+    "baseline_mirror": BaselineMirrorProvider,
+    "superprompt": SuperPromptProvider,
+}
+
+AVAILABLE_PROVIDERS = {**MODEL_PROVIDERS, **PIPELINE_PROVIDERS}
+
+__all__ = [
+    "ModelProvider",
+    "PipelineProvider",
+    "MirrorProvider",
+    "BaselineMirrorProvider",
+    "SuperPromptProvider",
+    "OpenAIProvider",
+    "OpenRouterProvider",
+    "AVAILABLE_PROVIDERS",
+    "MODEL_PROVIDERS",
+    "PIPELINE_PROVIDERS",
+]

--- a/llm_prag_benchmark/providers/base.py
+++ b/llm_prag_benchmark/providers/base.py
@@ -1,0 +1,29 @@
+from typing import List, Dict
+
+class BaseProvider:
+    """Common interface for all providers."""
+
+    def generate_response(self, conversation: List[Dict[str, str]]) -> str:
+        """Generate a response for the given conversation."""
+        raise NotImplementedError
+
+class ModelProvider(BaseProvider):
+    """Interface for providers that wrap a raw model API."""
+    pass
+
+class PipelineProvider(BaseProvider):
+    """Interface for providers that embed prompting or pipeline logic."""
+
+    def generate_immediate_response(self, conversation: List[Dict[str, str]]) -> str:
+        """Produce the direct assistant reply for the latest user message."""
+        raise NotImplementedError
+
+    def run_background_processor(self, conversation: List[Dict[str, str]]) -> None:
+        """Process background reasoning based on the conversation history."""
+        raise NotImplementedError
+
+    def generate_response(self, conversation: List[Dict[str, str]]) -> str:
+        """Default implementation using immediate response then background step."""
+        response = self.generate_immediate_response(conversation)
+        self.run_background_processor(conversation)
+        return response

--- a/llm_prag_benchmark/providers/openai_provider.py
+++ b/llm_prag_benchmark/providers/openai_provider.py
@@ -1,0 +1,23 @@
+import os
+from typing import List, Dict
+from openai import OpenAI
+from .base import ModelProvider
+
+class OpenAIProvider(ModelProvider):
+    """Model provider using the standard OpenAI API."""
+    def __init__(self, api_key=None, model="gpt-4o", temp=0.7):
+        self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if not self.api_key:
+            raise ValueError("OPENAI_API_KEY environment variable not set")
+        self.model = model
+        self.temperature = float(temp) if temp is not None else 0.7
+        self.client = OpenAI(api_key=self.api_key)
+
+    def generate_response(self, conversation: List[Dict[str, str]]) -> str:
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=conversation,
+            temperature=self.temperature,
+            max_tokens=1000,
+        )
+        return response.choices[0].message.content

--- a/llm_prag_benchmark/providers/openrouter_provider.py
+++ b/llm_prag_benchmark/providers/openrouter_provider.py
@@ -1,0 +1,31 @@
+import os
+from typing import List, Dict
+from openai import OpenAI
+from .base import ModelProvider
+
+class OpenRouterProvider(ModelProvider):
+    """Model provider using OpenRouter API."""
+    def __init__(self, api_key=None, model="gpt-4o", temp=0.7, site_name=None):
+        self.api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
+        if not self.api_key:
+            raise ValueError("OPENROUTER_API_KEY environment variable not set")
+        if model and model.startswith("openrouter/"):
+            model = model[len("openrouter/") :]
+        self.model = model
+        self.temperature = float(temp) if temp is not None else 0.7
+        self.site_name = site_name or os.getenv("OPENROUTER_SITE_NAME", "MIRROR-Benchmark")
+        self.client = OpenAI(api_key=self.api_key, base_url="https://openrouter.ai/api/v1")
+
+    def generate_response(self, conversation: List[Dict[str, str]]) -> str:
+        extra_headers = {
+            "HTTP-Referer": "https://github.com/your-repo",
+            "X-Title": self.site_name,
+        }
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=conversation,
+            temperature=self.temperature,
+            max_tokens=1000,
+            extra_headers=extra_headers,
+        )
+        return response.choices[0].message.content

--- a/llm_prag_benchmark/super_prompt_provider.py
+++ b/llm_prag_benchmark/super_prompt_provider.py
@@ -1,0 +1,42 @@
+import os
+from typing import List, Dict
+from openai import OpenAI
+from .providers.base import PipelineProvider
+
+PROMPT_PATH = os.path.join(os.path.dirname(__file__), "prompts", "super_prompt.txt")
+with open(PROMPT_PATH, "r", encoding="utf-8") as f:
+    SUPER_PROMPT = f.read()
+
+class SuperPromptProvider(PipelineProvider):
+    """Pipeline provider that sends a consolidated prompt in a single call."""
+
+    def __init__(self, api_key=None, model=None, temp=0.7):
+        self.api_key = api_key or os.environ.get("OPENROUTER_API_KEY")
+        if not self.api_key:
+            raise ValueError("OPENROUTER_API_KEY environment variable not set")
+
+        if model and model.startswith("openrouter/"):
+            model = model[len("openrouter/"):]
+        self.model = model or "gpt-4o"
+        self.temperature = float(temp) if temp is not None else 0.7
+
+        self.client = OpenAI(api_key=self.api_key, base_url="https://openrouter.ai/api/v1")
+
+    def generate_immediate_response(self, conversation: List[Dict[str, str]]) -> str:
+        messages = [{"role": "system", "content": SUPER_PROMPT}]
+        for msg in conversation:
+            messages.append({"role": msg["role"], "content": msg["content"]})
+
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            temperature=self.temperature,
+            max_tokens=1000,
+        )
+        return response.choices[0].message.content
+
+    def run_background_processor(self, conversation: List[Dict[str, str]]) -> None:
+        pass
+
+    def generate_response(self, conversation: List[Dict[str, str]]) -> str:
+        return self.generate_immediate_response(conversation)


### PR DESCRIPTION
## Summary
- introduce `BaselineMirrorProvider` exposing immediate response and background processing
- update provider interface and registry to support the new provider
- adapt existing pipeline providers to implement new methods
- mention the new provider in docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: dotenv, pandas)*

------
https://chatgpt.com/codex/tasks/task_b_683e781ba56c8333aad3b98fbefd2c4a